### PR TITLE
Fix xrandr script not running under LightDM in Nvidia mode 

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -330,8 +330,7 @@ def _setup_display_manager(display_manager):
             _create_file(LIGHTDM_SCRIPT_PATH, NVIDIA_XRANDR_SCRIPT.format("modesetting"))
         subprocess.run(['chmod','+x',LIGHTDM_SCRIPT_PATH], stdout=subprocess.DEVNULL)
         # create config
-        if not os.path.exists(os.path.dirname(LIGHTDM_CONFIG_PATH)):
-            _create_file(LIGHTDM_CONFIG_PATH, LIGHTDM_CONFIG_CONTENT)
+        _create_file(LIGHTDM_CONFIG_PATH, LIGHTDM_CONFIG_CONTENT)
     elif display_manager not in ['', 'gdm', 'gdm3']:
         print('Error: provided Display Manager is not valid')
         print('Supported Display Managers: gdm, sddm, lightdm')


### PR DESCRIPTION
I faced an issue where LightDM was not working only when switching to Nvidia (I think it worked first time but I don't remember exactly), hybrid and integrated worked fine, Nvidia mode also worked in SDDM but didn't in LightDM. After some digging I found that 20-nvidia.conf was not getting regenerated, causing xrandr script to not run.

This change ensures that 20-nvidia.conf always gets generated in LightDM for Nvidia mode.

Checking for lightdm.conf.d directory is not needed as it generates parent directories if it doesn't exist