### PR TITLE
envycontrol: Add support for EndeavourOS

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -346,6 +346,9 @@ def _rebuild_initramfs():
     # RHEL and SUSE derivatives
     elif os.path.exists('/etc/redhat-release') or os.path.exists('/usr/bin/zypper'):
         command = ['dracut', '--force', '--regenerate-all']
+    # EndeavourOS
+    elif os.path.exists('/usr/lib/endeavouros-release'):
+        command = ['dracut', '--force', '--regenerate-all']
     else:
         command = []
     if len(command) != 0:


### PR DESCRIPTION
EndeavourOS switched to `dracut` since Cassini-2002 release. This commit adds support to generate initramfs using `dracut` on EndeavourOS.

Source: <https://endeavouros.com/news/cassini-packed-with-new-features-is-here>