### PR TITLE
fix: can't find gpu if was integrated in v3.4.0

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -688,7 +688,7 @@ class CachedConfig:
 
 def get_current_mode():
     mode = 'hybrid'
-    if os.path.exists(BLACKLIST_PATH) and os.path.exists(UDEV_INTEGRATED_PATH):
+    if os.path.exists(BLACKLIST_PATH) and (os.path.exists(UDEV_INTEGRATED_PATH) or os.path.exists('/lib/udev/rules.d/50-remove-nvidia.rules')):
         mode = 'integrated'
     elif os.path.exists(XORG_PATH) and os.path.exists(MODESET_PATH):
         mode = 'nvidia'


### PR DESCRIPTION
Issue description and how to reproduce:

I was in integrated mode in version 3.4.0. But now I'm using version 3.5.0 and `envycontrol -q` wrongly shows I'm hybrid, and when I do `sudo envycontrol -s integrated`, it outpus error: "ERROR: Could not find Nvidia GPU\nTry switching to hybrid mode first!", switch to other modes also outputs this error. Expected behavior is `envycontrol -q` shows I'm integrated and `sudo envycontrol -s integrated` and other mode switches works.

Fix and reasons:

The problem is [line 590][0] `with CachedConfig(args).adapter():` goes to [line 621][1] check `if self.is_hybrid():` and that check returns I'm hybrid (but I'm not). The reason it return I'm hybrid is because in get_current_mode() function [line 691][2] `if os.path.exists(BLACKLIST_PATH) and os.path.exists(UDEV_INTEGRATED_PATH):` only checks new UDEV_INTEGRATED_PATH but not old `/lib/udev/rules.d/50-remove-nvidia.rules`. And the success check leads to calling line 622 create_cache_file() function, and calls get_nvidia_gpu_pci_bus() function, and get_nvidia_gpu_pci_bus() errors and exits because it can't find nvidia gpu in [line 396 and 397][3]. It can't find nvidia gpu because it wrongly thinks I'm hybrid (but I'm not). If it correctly thinks I'm not hybrid, it will just use cache and nvidia gpu will be found.

Thus, my fix is to check old UDEV_INTEGRATED_PATH `/lib/udev/rules.d/50-remove-nvidia.rules` in get_current_mode() and if old path exist it will correctly report I'm integrated.

[0]:https://github.com/bayasdev/envycontrol/blob/fba8c6d790ac3d67bd46943ca2bc69606ffa1e18/envycontrol.py#L590
[1]:https://github.com/bayasdev/envycontrol/blob/fba8c6d790ac3d67bd46943ca2bc69606ffa1e18/envycontrol.py#L621
[2]:https://github.com/bayasdev/envycontrol/blob/fba8c6d790ac3d67bd46943ca2bc69606ffa1e18/envycontrol.py#L691
[3]:https://github.com/bayasdev/envycontrol/blob/fba8c6d790ac3d67bd46943ca2bc69606ffa1e18/envycontrol.py#L396-L397