### PR TITLE
Bump flake to 3.5.2 too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       packages.${system} = {
         envycontrol = pkgs.python3Packages.buildPythonPackage {
           pname = "envycontrol";
-          version = "3.5.1";
+          version = "3.5.2";
           src = self;
         };
         default = self.packages.${system}.envycontrol;


### PR DESCRIPTION
I have no idea how this was forgotten but here you go.

The lack of this change doesn't impact the version installed on the system.