### PR TITLE
feat: determine initramfs tool by command presence instead of release files

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import shutil
 from contextlib import contextmanager
 
 # begin constants definition
@@ -482,26 +483,25 @@ def rebuild_initramfs():
         print('Rebuilding the initramfs with rpm-ostree...')
         command = ['rpm-ostree', 'initramfs', '--enable', '--arg=--force']
 
-    # Debian and Ubuntu derivatives
-    elif os.path.exists('/etc/debian_version'):
+    # Check for available initramfs tools based on commands
+    elif shutil.which('update-initramfs'):
         command = ['update-initramfs', '-u', '-k', 'all']
-    # RHEL and SUSE derivatives
-    elif os.path.exists('/etc/redhat-release') or os.path.exists('/usr/bin/zypper'):
-        command = ['dracut', '--force', '--regenerate-all']
-    # EndeavourOS with dracut
-    elif os.path.exists('/usr/lib/endeavouros-release') and os.path.exists('/usr/bin/dracut'):
+    elif shutil.which('dracut-rebuild'):
         command = ['dracut-rebuild']
-    # ALT Linux
-    elif os.path.exists('/etc/altlinux-release'):
+    elif shutil.which('dracut'):
+        command = ['dracut', '--force', '--regenerate-all']
+    elif shutil.which('make-initrd'):
         command = ['make-initrd']
-    # Arch Linux
-    elif os.path.exists('/etc/arch-release'):
+    elif shutil.which('mkinitcpio'):
         command = ['mkinitcpio', '-P']
+    elif os.path.exists('/usr/lib/booster/regenerate_images'):
+        command = ['/usr/lib/booster/regenerate_images']
     else:
         command = []
+        logging.warning("No supported initramfs tool found (update-initramfs, dracut, dracut-rebuild, make-initrd, mkinitcpio, or booster)")
 
     if len(command) != 0:
-        print('Rebuilding the initramfs...')
+        print(f'Rebuilding the initramfs with {" ".join(command)}...')
         if logging.getLogger().level == logging.DEBUG:
             p = subprocess.run(command)
         else:
@@ -510,8 +510,9 @@ def rebuild_initramfs():
         if p.returncode == 0:
             print('Successfully rebuilt the initramfs!')
         else:
-            logging.error("An error ocurred while rebuilding the initramfs")
-
+            logging.error(f"An error occurred while rebuilding the initramfs with {' '.join(command)}")
+    else:
+        logging.error("No command available to rebuild initramfs")
 
 def create_file(path, content, executable=False):
     try:


### PR DESCRIPTION
The previous implementation of rebuild_initramfs() relied on checking the distribution's release files (e.g. /etc/arch-release, /etc/debian_version) to determine the appropriate initramfs tool. This approach was unreliable because the release files may not indicate the actual initramfs tool in use, especially in Arch Linux where multiple tools such as mkinitcpio, dracut, or booster may be configured. The new implementation solves this problem by using shutil.which to determine if certain commands (update-initramfs, dracut, mkinitcpio, /usr/lib/booster/regenerate_images, etc.) are present, providing a more reliable and universal method of selecting the correct initramfs tool