### PR TITLE
feat: inhibit sleep/shutdown while rebuilding initramfs

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import shutil
 from contextlib import contextmanager
 
 # begin constants definition
@@ -503,6 +504,15 @@ def rebuild_initramfs():
         command = ['mkinitcpio', '-P']
     else:
         command = []
+
+    if shutil.which("systemd-inhibit"):
+        command = [
+            'systemd-inhibit',
+            '--who=envycontrol',
+            '--why', 'Rebuilding initramfs',
+            '--',
+            *command
+        ]
 
     if len(command) != 0:
         print('Rebuilding the initramfs...')


### PR DESCRIPTION
Currently, a user can accidentally reboot their machine while the initramfs is being regenerated. This can land them in a state where envycontrol's mode is not in-sync with the initramfs. This mistake is particularly easy to make when using envycontrol from a taskbar widget, where you don't have a terminal session that's blocked by regenerating.

With this PR, envycontrol will now use `systemd-inhibit` (when available) to prevent shutdown/sleep while regenerating.