### PR TITLE
Fix crashes and improve hybrid mode handling in EnvyControl

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -647,7 +647,11 @@ class CachedConfig:
         global get_nvidia_gpu_pci_bus
         use_cache = os.path.exists(CACHE_FILE_PATH)
 
-        if self.is_hybrid():  # recreate cache file when in hybrid mode
+        # Only cache the GPU PCI bus when leaving hybrid mode.
+        # Switching *to* hybrid never needs the cached value and the GPU
+        # may not be visible via lspci if old udev removal rules are still
+        # in place, which would make create_cache_file() exit early.
+        if self.is_hybrid() and self.app_args.switch != 'hybrid':
             self.create_cache_file()
 
         if use_cache:
@@ -717,7 +721,9 @@ class CachedConfig:
 
 def get_current_mode():
     mode = 'hybrid'
-    if os.path.exists(BLACKLIST_PATH) and (os.path.exists(UDEV_INTEGRATED_PATH) or os.path.exists('/lib/udev/rules.d/50-remove-nvidia.rules')):
+    if (os.path.exists(BLACKLIST_PATH) or
+            os.path.exists(UDEV_INTEGRATED_PATH) or
+            os.path.exists('/lib/udev/rules.d/50-remove-nvidia.rules')):
         mode = 'integrated'
     elif os.path.exists(XORG_PATH) and os.path.exists(MODESET_PATH):
         mode = 'nvidia'

--- a/envycontrol.py
+++ b/envycontrol.py
@@ -470,6 +470,7 @@ def get_amd_igpu_name():
     except subprocess.CalledProcessError:
         logging.warning(
             "Failed to run the 'xrandr' command.")
+        return None
 
     pattern = re.compile(r'(name:).*(ATI*|AMD*|AMD\/ATI)*')
 


### PR DESCRIPTION
This pull request makes several improvements to the GPU detection and mode switching logic in `envycontrol.py`, focusing on more robust handling of cache creation, error handling, and mode detection. The changes ensure better reliability when switching GPU modes, especially in hybrid configurations.

**Improvements to GPU mode switching and cache management:**

* Changed cache file creation logic in the `adapter` method so that the cache is only recreated when leaving hybrid mode, preventing unnecessary cache updates and handling cases where the GPU may not be visible due to old udev rules.

**Error handling and robustness:**

* Added a `return None` statement in `get_amd_igpu_name()` if the `xrandr` command fails, ensuring the function exits gracefully on error.

**Mode detection logic:**

* Updated `get_current_mode()` to consider the system to be in 'integrated' mode if any of the relevant files exist (using logical ORs), instead of requiring both `BLACKLIST_PATH` and one of the udev rules to exist, making the detection logic more accurate and flexible.